### PR TITLE
Remove topic unsubscribe option

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ android {
 android.applicationVariants.all { variant ->
     def shouldProcessGoogleServices = variant.flavorName == "play"
     def googleTask = tasks.findByName("process${variant.name.capitalize()}GoogleServices")
-    googleTask.enabled = shouldProcessGoogleServices
+    googleTask?.enabled = shouldProcessGoogleServices
 }
 
 // Strips out REQUEST_INSTALL_PACKAGES permission for Google Play variant
@@ -127,5 +127,5 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 
     // Image viewer
-    implementation 'com.github.stfalcon-studio:StfalconImageViewer:v1.0.1'
+    implementation 'com.github.stfalcon-studio:StfalconImageViewer:1.0.1'
 }

--- a/app/src/main/java/io/heckel/ntfy/ui/DetailActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/DetailActivity.kt
@@ -381,10 +381,6 @@ class DetailActivity : AppCompatActivity(), ActionMode.Callback, NotificationFra
                 onSettingsClick()
                 true
             }
-            R.id.detail_menu_unsubscribe -> {
-                onDeleteClick()
-                true
-            }
             else -> super.onOptionsItemSelected(item)
         }
     }
@@ -595,33 +591,6 @@ class DetailActivity : AppCompatActivity(), ActionMode.Callback, NotificationFra
         intent.putExtra(EXTRA_SUBSCRIPTION_TOPIC, subscriptionTopic)
         intent.putExtra(EXTRA_SUBSCRIPTION_DISPLAY_NAME, subscriptionDisplayName)
         startActivity(intent)
-    }
-
-    private fun onDeleteClick() {
-        Log.d(TAG, "Deleting subscription ${topicShortUrl(subscriptionBaseUrl, subscriptionTopic)}")
-
-        val builder = AlertDialog.Builder(this)
-        val dialog = builder
-            .setMessage(R.string.detail_delete_dialog_message)
-            .setPositiveButton(R.string.detail_delete_dialog_permanently_delete) { _, _ ->
-                Log.d(TAG, "Deleting subscription with subscription ID $subscriptionId (topic: $subscriptionTopic)")
-                GlobalScope.launch(Dispatchers.IO) {
-                    repository.removeAllNotifications(subscriptionId)
-                    repository.removeSubscription(subscriptionId)
-                    if (subscriptionBaseUrl == appBaseUrl) {
-                        messenger.unsubscribe(subscriptionTopic)
-                    }
-                }
-                finish()
-            }
-            .setNegativeButton(R.string.detail_delete_dialog_cancel) { _, _ -> /* Do nothing */ }
-            .create()
-        dialog.setOnShowListener {
-            dialog
-                .getButton(AlertDialog.BUTTON_POSITIVE)
-                .dangerButton(this)
-        }
-        dialog.show()
     }
 
     private fun onNotificationClick(notification: Notification) {

--- a/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
@@ -3,7 +3,6 @@ package io.heckel.ntfy.ui
 import android.Manifest
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
-import android.app.AlertDialog
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -503,9 +502,7 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
     }
 
     private fun onSubscriptionItemLongClick(subscription: Subscription) {
-        if (actionMode == null) {
-            beginActionMode(subscription)
-        }
+        // Deletion of subscriptions is disabled; ignore long clicks.
     }
 
     private fun refreshAllSubscriptions() {
@@ -596,35 +593,8 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
     }
 
     override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
-        return when (item?.itemId) {
-            R.id.main_action_mode_delete -> {
-                onMultiDeleteClick()
-                true
-            }
-            else -> false
-        }
-    }
-
-    private fun onMultiDeleteClick() {
-        Log.d(DetailActivity.TAG, "Showing multi-delete dialog for selected items")
-
-        val builder = AlertDialog.Builder(this)
-        val dialog = builder
-            .setMessage(R.string.main_action_mode_delete_dialog_message)
-            .setPositiveButton(R.string.main_action_mode_delete_dialog_permanently_delete) { _, _ ->
-                adapter.selected.map { subscriptionId -> viewModel.remove(this, subscriptionId) }
-                finishActionMode()
-            }
-            .setNegativeButton(R.string.main_action_mode_delete_dialog_cancel) { _, _ ->
-                finishActionMode()
-            }
-            .create()
-        dialog.setOnShowListener {
-            dialog
-                .getButton(AlertDialog.BUTTON_POSITIVE)
-                .dangerButton(this)
-        }
-        dialog.show()
+        // No actions; deletion of subscriptions is disabled.
+        return false
     }
 
     override fun onDestroyActionMode(mode: ActionMode?) {

--- a/app/src/main/res/menu/menu_detail_action_bar.xml
+++ b/app/src/main/res/menu/menu_detail_action_bar.xml
@@ -13,5 +13,4 @@
     <item android:id="@+id/detail_menu_copy_url" android:title="@string/detail_menu_copy_url"/>
     <item android:id="@+id/detail_menu_clear" android:title="@string/detail_menu_clear"/>
     <item android:id="@+id/detail_menu_test" android:title="@string/detail_menu_test"/>
-    <item android:id="@+id/detail_menu_unsubscribe" android:title="@string/detail_menu_unsubscribe"/>
 </menu>

--- a/app/src/main/res/menu/menu_main_action_mode.xml
+++ b/app/src/main/res/menu/menu_main_action_mode.xml
@@ -1,4 +1,1 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
-    <item android:id="@+id/main_action_mode_delete" android:title="@string/main_action_mode_menu_unsubscribe"
-          android:icon="@drawable/ic_delete_white_20dp"/>
-</menu>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
## Summary
- use null-safe Google Services task toggling for F-Droid builds
- block topic removal by ignoring long presses and dropping delete dialog
- keep only notification and utility actions in topic detail menu
- fix StfalconImageViewer dependency version so builds resolve the library

## Testing
- `JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java)))) ./gradlew assembleFdroidRelease --console plain` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6891e6fc08408322b8c899ea663401a1